### PR TITLE
修复get_text_idx函数，将中文词转为id时最后一个词匹配错误的bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ tensorflow  1.x
 运行验证：python eval.py<br /> 
  
 
- ![image](https://github.com/norybaby/sentiment_analysis_textcnn/blob/master/accuracy.png)
+ ![image](https://github.com/burette/sentiment_analysis_textcnn/blob/master/accuracy.png)
 
 <br /> <br /> 
  
-如有问题欢迎讨论 xiuyunchen@126.com
+如有问题欢迎讨论 lizhiwenbit@126.com
 

--- a/textcnn/data_input_helper.py
+++ b/textcnn/data_input_helper.py
@@ -123,7 +123,11 @@ def get_text_idx(text,vocab,max_document_length):
     text_array = np.zeros([len(text), max_document_length],dtype=np.int32)
 
     for i,x in  enumerate(text):
-        words = x.split(" ")
+        # 每一行最后一个词与'\n'在一起，因此需要先除去换行符，否则最后一个词无法正确对应到id，为unknown
+        words = x.replace("\n", "").split(" ")
+        # 另外观察发现，原来分割的方式每行第一个字符均为空，对应为unknown，因此在这里个人认为应该除去第一个空格
+        # eg: ['', '房间', '设施', '难以', '够得上', '五星级', '服务', '不错', '送', '水果']
+        words = words[1:]
         for j, w in enumerate(words):
             if w in vocab:
                 text_array[i, j] = vocab[w]


### PR DESCRIPTION
你好，在研究你的代码的时候，发现get_text_idx函数的处理稍有瑕疵，个人进行一些调整，望能并入给更多人的看到。
仔细地说，举个例子。
文本中：”0 	标准间 太 差   房间 不如 星   而且 设施 非常 陈旧 建议 酒店 把 老 标准间 从 新 改善 “
你原来最后一个单词为[...，'改善\n']，无法匹配到词库中到id，匹配到unknown。
详见代码，欢迎交流